### PR TITLE
Add modified timestamps

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
 				"@fontsource/fira-mono": "^4.5.0",
 				"axios": "^0.27.2",
 				"cookie": "^0.4.1",
+				"moment": "^2.29.4",
 				"svelte-inview": "^3.0.1"
 			},
 			"devDependencies": {
@@ -2729,6 +2730,14 @@
 			"dev": true,
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/moment": {
+			"version": "2.29.4",
+			"resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+			"integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/mri": {
@@ -5734,6 +5743,11 @@
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
 			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
 			"dev": true
+		},
+		"moment": {
+			"version": "2.29.4",
+			"resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+			"integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
 		},
 		"mri": {
 			"version": "1.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,6 +33,7 @@
 		"@fontsource/fira-mono": "^4.5.0",
 		"axios": "^0.27.2",
 		"cookie": "^0.4.1",
+		"moment": "^2.29.4",
 		"svelte-inview": "^3.0.1"
 	}
 }

--- a/frontend/src/routes/applications/+page.svelte
+++ b/frontend/src/routes/applications/+page.svelte
@@ -391,7 +391,6 @@
 		selectedAppPublic = appDetail.data.public;
 		selectedAppDateUpdated = appDetail.data.dateUpdated;
 		isPublic = selectedAppPublic;
-		console.log(appDetail.data);
 		curlCommandsDecode();
 	};
 

--- a/frontend/src/routes/applications/+page.svelte
+++ b/frontend/src/routes/applications/+page.svelte
@@ -160,7 +160,8 @@
 		selectedAppGroupName,
 		selectedAppDescription,
 		selectedAppDescriptionSelector,
-		selectedAppPublic;
+		selectedAppPublic,
+		selectedAppDateUpdated;
 
 	// Validation
 	let previousAppName;
@@ -388,8 +389,9 @@
 		selectedAppGroupName = appDetail.data.groupName;
 		selectedAppDescription = appDetail.data.description;
 		selectedAppPublic = appDetail.data.public;
+		selectedAppDateUpdated = appDetail.data.dateUpdated;
 		isPublic = selectedAppPublic;
-
+		console.log(appDetail.data);
 		curlCommandsDecode();
 	};
 
@@ -950,11 +952,13 @@
 								{selectedAppName}
 								{selectedAppDescription}
 								{selectedAppPublic}
+								{selectedAppDateUpdated}
 								appCurrentGroupPublic={$groupContext?.public}
 								on:deleteTopicApplicationAssociation={(e) => {
 									deleteTopicApplicationAssociation(e.detail);
 								}}
 								on:reloadAllApps={() => reloadAllApps()}
+								on:loadApplicationDetail={() => loadApplicationDetail(selectedAppId, selectedAppGroupId)}
 							/>
 
 							<div style="display: inline-flex; height: 7rem; margin-left: -1rem">

--- a/frontend/src/routes/applications/ApplicationDetails.svelte
+++ b/frontend/src/routes/applications/ApplicationDetails.svelte
@@ -1,6 +1,7 @@
 <!-- Copyright 2023 DDS Permissions Manager Authors-->
 <script>
 	import { createEventDispatcher, onDestroy, onMount } from 'svelte';
+	import moment from 'moment';
 	import { page } from '$app/stores';
 	import { isAdmin } from '../../stores/authentication';
 	import { httpAdapter } from '../../appconfig';
@@ -20,6 +21,7 @@
 		selectedAppPublic,
 		appCurrentGroupPublic,
 		selectedAppGroupName,
+		selectedAppDateUpdated = '',
 		selectedTopicApplications = [];
 
 	const dispatch = createEventDispatcher();
@@ -120,6 +122,7 @@
 				}
 			});
 		dispatch('reloadAllApps');
+		dispatch('loadApplicationDetail');
 		resumeSocketListener();
 	};
 
@@ -180,6 +183,9 @@
 			appCurrentGroupPublic = await getGroupVisibilityPublic(selectedAppGroupName);
 		}
 	});
+
+	$: timeAgo = moment(selectedAppDateUpdated).fromNow();
+	$: browserFormat = new Date(selectedAppDateUpdated).toLocaleString();
 
 	onDestroy(() => {
 		socket.close();
@@ -287,6 +293,8 @@
 			</td>
 		</tr>
 	</table>
+
+	{#if selectedAppDateUpdated} <p style="font-style: italic;">Last updated {timeAgo} ({browserFormat})</p> {/if}
 
 	{#if !$page.url.pathname.includes('search')}
 		<div style="margin-top: 3.5rem">

--- a/frontend/src/routes/topics/TopicDetails.svelte
+++ b/frontend/src/routes/topics/TopicDetails.svelte
@@ -294,7 +294,7 @@
 			});
 
 			dispatch('reloadTopics');
-			await fetchAndSetTopicDetails();
+			await fetchAndUpdateTopic();
 			resumeSocketListener();
 			selectedTopicDescription = newTopicDescription;
 			isPublic = newTopicPublic;

--- a/frontend/src/routes/topics/TopicDetails.svelte
+++ b/frontend/src/routes/topics/TopicDetails.svelte
@@ -2,6 +2,7 @@
 <script>
 	import { isAuthenticated, isAdmin } from '../../stores/authentication';
 	import { onMount, createEventDispatcher, onDestroy } from 'svelte';
+	import moment from 'moment';
 	import { page } from '$app/stores';
 	import { httpAdapter } from '../../appconfig';
 	import topicDetails from '../../stores/groupDetails';
@@ -91,6 +92,7 @@
 	//Grant
 	let editGrant = false;
 
+
 	// Websocket
 	let topicSocketIsPaused = false;
 
@@ -110,7 +112,6 @@
 		isPublic = $topicDetails.public;
 
 		topicCurrentGroupPublic = await getGroupVisibilityPublic(selectedTopicGroupName);
-
 		headerTitle.set(selectedTopicName);
 		detailView.set(true);
 	};
@@ -293,6 +294,7 @@
 			});
 
 			dispatch('reloadTopics');
+			await fetchAndSetTopicDetails();
 			resumeSocketListener();
 			selectedTopicDescription = newTopicDescription;
 			isPublic = newTopicPublic;
@@ -327,6 +329,9 @@
 		checkboxes = Array.from(checkboxes);
 		return checkboxes.filter((checkbox) => checkbox.checked === true).length;
 	};
+
+	$: timeAgo = moment($topicDetails?.dateUpdated).fromNow();
+	$: browserFormat = new Date($topicDetails?.dateUpdated).toLocaleString();
 </script>
 
 {#if $isAuthenticated}
@@ -518,6 +523,7 @@
 				/>
 			{/if}
 		</div>
+		{#if $topicDetails.dateUpdated} <p style="font-style: italic;">Last updated {timeAgo} ({browserFormat})</p> {/if}
 
 		{#if !$page.url.pathname.includes('search')}
 			<div>

--- a/frontend/src/stores/groupDetails.js
+++ b/frontend/src/stores/groupDetails.js
@@ -13,6 +13,6 @@
 // limitations under the License.
 import { writable } from 'svelte/store';
 
-const groupDetails = writable(null);
+const groupDetails = writable({});
 
 export default groupDetails;


### PR DESCRIPTION
**Task:** [Front End: Add Modified Timestamp To Detail Pages](https://3.basecamp.com/5573843/buckets/31804935/card_tables/cards/6396652190/edit?focus=kanban_card_title)

**Acceptance Criteria:** As a user, I want to see a timestamp indicating last time modified for entities displayed on the detail page.  The application should show the date when the information was retrieved.

**Screenshots:** 

Topics Page
<img width="1169" alt="Screenshot 2023-08-25 at 6 14 58 PM" src="https://github.com/OpenDDS/DDSPermissionsManager/assets/91141681/c8cc8a7c-471d-45b2-b6a3-6d2662565e4c">


Applications Page
<img width="1212" alt="Screenshot 2023-08-25 at 6 15 08 PM" src="https://github.com/OpenDDS/DDSPermissionsManager/assets/91141681/16f8059d-2985-4b47-bd1a-bec48ee1f94d">

