### PR TITLE
Add durationMetadata to GrantDTO

### DIFF
--- a/app/src/main/java/io/unityfoundation/dds/permissions/manager/model/applicationgrant/ApplicationGrantService.java
+++ b/app/src/main/java/io/unityfoundation/dds/permissions/manager/model/applicationgrant/ApplicationGrantService.java
@@ -184,7 +184,8 @@ public class ApplicationGrantService {
                 applicationGrant.getPermissionsApplication().getPermissionsGroup().getName(),
                 applicationGrant.getPermissionsGroup().getId(),
                 applicationGrant.getPermissionsGroup().getName(),
-                applicationGrant.getGrantDuration().getDurationInMilliseconds()
+                applicationGrant.getGrantDuration().getDurationInMilliseconds(),
+                applicationGrant.getGrantDuration().getDurationMetadata()
         );
     }
 

--- a/app/src/main/java/io/unityfoundation/dds/permissions/manager/model/applicationgrant/dto/GrantDTO.java
+++ b/app/src/main/java/io/unityfoundation/dds/permissions/manager/model/applicationgrant/dto/GrantDTO.java
@@ -26,8 +26,9 @@ public class GrantDTO implements EntityDTO {
     private final Long groupId;
     private final String groupName;
     private final Long durationInMilliseconds;
+    private final String durationMetadata;
 
-    public GrantDTO(Long id, String name, Long applicationId, String applicationName, String applicationGroupName, Long groupId, String groupName, Long durationInMilliseconds) {
+    public GrantDTO(Long id, String name, Long applicationId, String applicationName, String applicationGroupName, Long groupId, String groupName, Long durationInMilliseconds, String durationMetadata) {
         this.id = id;
         this.name = name;
         this.applicationId = applicationId;
@@ -36,6 +37,7 @@ public class GrantDTO implements EntityDTO {
         this.groupId = groupId;
         this.groupName = groupName;
         this.durationInMilliseconds = durationInMilliseconds;
+        this.durationMetadata = durationMetadata;
     }
 
 
@@ -70,5 +72,9 @@ public class GrantDTO implements EntityDTO {
 
     public Long getDurationInMilliseconds() {
         return durationInMilliseconds;
+    }
+
+    public String getDurationMetadata() {
+        return durationMetadata;
     }
 }

--- a/app/src/test/java/io/unityfoundation/dds/permissions/manager/ApplicationGrantApiTest.java
+++ b/app/src/test/java/io/unityfoundation/dds/permissions/manager/ApplicationGrantApiTest.java
@@ -206,11 +206,12 @@ public class ApplicationGrantApiTest {
             Long applicationGroupId = applicationOne.getPermissionsGroup().getId();
 
             // create grant duration
-            response = createGrantDuration("30s Duration", applicationGroupId);
+            response = createGrantDuration("30s Duration", applicationGroupId, "WEEKS");
             assertEquals(OK, response.getStatus());
             Optional<GrantDurationDTO> durationOptional = response.getBody(GrantDurationDTO.class);
             assertTrue(durationOptional.isPresent());
             assertEquals("30s Duration", durationOptional.get().getName());
+            assertEquals("WEEKS", durationOptional.get().getDurationMetadata());
 
             // generate grant token for application
             request = HttpRequest.GET("/applications/generate_grant_token/" + applicationOneId);
@@ -225,6 +226,8 @@ public class ApplicationGrantApiTest {
             assertEquals(CREATED, response.getStatus());
             Optional<GrantDTO> grantOptional = response.getBody(GrantDTO.class);
             assertTrue(grantOptional.isPresent());
+            assertEquals(30000, grantOptional.get().getDurationInMilliseconds());
+            assertEquals("WEEKS", grantOptional.get().getDurationMetadata());
 
             // update the grant
             UpdateGrantDTO updateGrantDTO = new UpdateGrantDTO();
@@ -1092,10 +1095,15 @@ public class ApplicationGrantApiTest {
     }
 
     private HttpResponse<?> createGrantDuration(String name, Long groupId) {
+        return createGrantDuration(name, groupId, null);
+    }
+
+    private HttpResponse<?> createGrantDuration(String name, Long groupId, String durationMetadata) {
         CreateGrantDurationDTO abcDTO = new CreateGrantDurationDTO();
         abcDTO.setName(name);
         abcDTO.setGroupId(groupId);
         abcDTO.setDurationInMilliseconds(30000L);
+        abcDTO.setDurationMetadata(durationMetadata);
 
 
         HttpRequest<?> request = HttpRequest.POST("/grant_durations", abcDTO);


### PR DESCRIPTION
If Duration name is needed in Application Grant API responses, we'd essentially add the same code as this PR but with name.